### PR TITLE
Correção da implementação de dependências na chamada wp_enqueue_script

### DIFF
--- a/Controllers/ShowCalculatorProductPage.php
+++ b/Controllers/ShowCalculatorProductPage.php
@@ -36,9 +36,9 @@ class ShowCalculatorProductPage
      */
     public function enqueueCssJsFrontend()
     {
-        wp_enqueue_script('produto', BASEPLUGIN_ASSETS . '/js/shipping-product-page.js?hash=' . rand(0,1000), 'jquery');
-        wp_enqueue_script('produto-variacao', BASEPLUGIN_ASSETS . '/js/shipping-product-page-variacao.js?hash=' . rand(0,1000), 'jquery');
-        wp_enqueue_script('calculator', BASEPLUGIN_ASSETS . '/js/calculator.js?hash=' . rand(0,1000), 'jquery');
+        wp_enqueue_script('produto', BASEPLUGIN_ASSETS . '/js/shipping-product-page.js?hash=' . rand(0,1000), array('jquery'));
+        wp_enqueue_script('produto-variacao', BASEPLUGIN_ASSETS . '/js/shipping-product-page-variacao.js?hash=' . rand(0,1000), array('jquery'));
+        wp_enqueue_script('calculator', BASEPLUGIN_ASSETS . '/js/calculator.js?hash=' . rand(0,1000), array('jquery'));
     }
 
     /**


### PR DESCRIPTION
Estava tendo um problema em que os scripts da calculadora falhava devido ao jQuery ainda não ter sido carregado.
Verificando a implementação da inclusão desses scripts, deu pra ver o parâmetro de especificações de dependência estava apenas como uma string 'jquery'.

Seguindo a documentação do WordPress https://developer.wordpress.org/reference/functions/wp_enqueue_script/, essas dependências devem ser passadas em um array().

Corrigindo isso, a calculadora agora funciona normalmente.

Esse problema ocorre por que alguns temas, como no meu caso, podem mover o jQuery para o footer ou alterar sua prioridade de carregamento, a fim de conseguir uma melhor pontuação no Google PageSpeed.

Como a implementação da dependência do jQuery estava errada antes, o WordPress então carregava os js do Melhor Envio antes do mesmo, quebrando sua funcionalidade.
