### PR TITLE
Fix function getMethodsActivedsMelhorEnvio()

### DIFF
--- a/Services/ShippingMelhorEnvioService.php
+++ b/Services/ShippingMelhorEnvioService.php
@@ -61,7 +61,7 @@ class ShippingMelhorEnvioService
 	foreach ( $shipping_methods as $method ) {
       		if ( isset( $method->enabled ) && 'yes' === $method->enabled ) {
         	$methods[] = $method;
-	      };
+	      }
 	}
 
 	return $methods;

--- a/Services/ShippingMelhorEnvioService.php
+++ b/Services/ShippingMelhorEnvioService.php
@@ -55,20 +55,17 @@ class ShippingMelhorEnvioService
      *
      * @return array
      */
-    public function getMethodsActivedsMelhorEnvio()
-    {
-        $methods = array();
-        $delivery_zones = \WC_Shipping_Zones::get_zones();
-        foreach ($delivery_zones as  $zone) {
-            foreach ($zone['shipping_methods'] as $method) {
-                if (!$this->isMelhorEnvioMethod($method)) {
-                    continue;
-                }
-                $methods[] = $method;
-            }
-        }
-        return $methods;
-    }
+    public static function getMethodsActivedsMelhorEnvio() {
+      	$methods   = array();
+	$shipping_methods = WC()->shipping()->get_shipping_methods();
+	foreach ( $shipping_methods as $method ) {
+      		if ( isset( $method->enabled ) && 'yes' === $method->enabled ) {
+        	$methods[] = $method;
+	      };
+	}
+
+	return $methods;
+  }
 
     /**
      * Function to check if the method is Melhor Envio.


### PR DESCRIPTION
This function check if exist a Melhor Envio shipping method in all shipping zones, but if the store is set to use a Melhor Envio shipping method in all situations (without a zone), the plugin show a alert message that don't exist a shipping method configured. This fix change the function to check if exist a Melhor Envio method active, independent if it is in a zone or not.