### PR TITLE
feat: add status delivery on list orders

### DIFF
--- a/assets/src/admin/components/Pedido/Documentos.vue
+++ b/assets/src/admin/components/Pedido/Documentos.vue
@@ -69,6 +69,7 @@
           <span v-if="item.status == status.STATUS_POSTED"
             >Etiqueta postada</span
           >
+          <span v-if="item.status == status.STATUS_DELIVERED">Entregue</span>
         </b>
       </p>
     </template>

--- a/assets/src/admin/components/Pedido/Documentos.vue
+++ b/assets/src/admin/components/Pedido/Documentos.vue
@@ -57,19 +57,19 @@
     <template v-else>
       <p>
         <b>
-          <span v-if="item.status == status.STATUS_GENERATED"
+          <span v-if="item.status === status.STATUS_GENERATED"
             >Pronta para imprimir</span
           >
-          <span v-if="item.status == status.STATUS_PAID"
+          <span v-if="item.status === status.STATUS_PAID"
             >Pronta para imprimir</span
           >
-          <span v-if="item.status == status.STATUS_RELEASED"
+          <span v-if="item.status === status.STATUS_RELEASED"
             >Pronta para imprimir</span
           >
-          <span v-if="item.status == status.STATUS_POSTED"
+          <span v-if="item.status === status.STATUS_POSTED"
             >Etiqueta postada</span
           >
-          <span v-if="item.status == status.STATUS_DELIVERED">Entregue</span>
+          <span v-if="item.status === status.STATUS_DELIVERED">Entregue</span>
         </b>
       </p>
     </template>


### PR DESCRIPTION
Se aplicado, esse PR adiciona o status de "Entregue" na listagem de pedidos no painel administrativo, antes não era exibido nenhum status para o cliente quando a etiqueta tinha o status delivered.

![Melhor Envio ‹ Tessmann Store — WordPress](https://user-images.githubusercontent.com/8430333/169128349-4e1e2a93-849f-4a10-8687-65907a869078.png)

