### PR TITLE
Permite utilizar o watch mode webpack

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,3 +1,3 @@
 {
-  "proxyURL": "http://wp.test/wp-admin/admin.php?page=vue-app"
+  "proxyURL": "localhost:8000"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "node" : ">=14.18.0"
     },
     "scripts": {
-        "dev": "cross-env WEBPACK_ENV=development webpack --progress --colors --watch --hide-modules",
+        "dev": "cross-env WEBPACK_ENV=development webpack --progress --color --watch",
         "dev-build": "cross-env WEBPACK_ENV=development webpack",
         "build": "cross-env WEBPACK_ENV=production webpack"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,13 +34,17 @@ const extractCss = new MiniCssExtractPlugin({
 
 const browserSyncPlugin = new BrowserSyncPlugin({
     proxy: {
-        target: config.proxyURL
+        target: config.proxyURL,
     },
-    files: [
+    files: [        
+        'assets/js/*.js',
+        'assets/css/*.css',
+        'assets/src/**/*.js',
         '**/*.php'
     ],
     cors: true,
-    reloadDelay: 0
+    reloadDelay: 0,
+    reload: true   
 });
 
 // Differ settings based on production flag


### PR DESCRIPTION
Se aprovado, esse PR:

- Volta a permitir utilizar o develpoment para o Webpack, deixando a faze de desenvolvimento melhor.

Observações:
1. Para utilizar o watch mode, a página deve ser recarregada ao realizar modificação (CTRL+R), não foi atualizada para utilizar o hot-reload.
2. Existe um processo manual na classe assets, onde deve ser removido a palavra ".min" dos arquivos para que seja mapeado os arquivos em dev

Ambas situações acima serão corrigidas/melhoradas no futuro.