### PR TITLE
feat: up version PHP to 7.2

### DIFF
--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -13,7 +13,7 @@ License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: baseplugin
 Tested up to: 6.0
-Requires PHP: 5.6
+Requires PHP: 7.2
 WC requires at least: 4.0
 WC tested up to: 6.2
 Domain Path: /languages

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam
 Requires at least: 4.7
 Tested up to: 6.0
 Stable tag: 2.11.28
-Requires PHP: 5.6+
+Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
 License: GPLv2 or later


### PR DESCRIPTION
Se aplicado, esse PR irá subir a versão mínima do PHP de 5.6 para 7.2, com isso irá resolver alguns problemas do plugin e estará adequado com os requerimentos mínimos do WooCommerce.

![WooCommerce-–-Plugin-WordPress-WordPress-org-Brasil](https://user-images.githubusercontent.com/8430333/180209711-bb3fbeb5-b283-487e-b47d-db73ba5b9ca4.png)

