### PR TITLE
Correções

### DIFF
--- a/Controllers/ShowCalculatorProductPage.php
+++ b/Controllers/ShowCalculatorProductPage.php
@@ -35,9 +35,9 @@ class ShowCalculatorProductPage {
 	 * @return void
 	 */
 	public function enqueueCssJsFrontend() {
-		wp_enqueue_script( 'produto', BASEPLUGIN_ASSETS . '/js/shipping-product-page.js', array( 'jquery' ) );
-		wp_enqueue_script( 'produto-variacao', BASEPLUGIN_ASSETS . '/js/shipping-product-page-variacao.js', array( 'jquery' ) );
-		wp_enqueue_script( 'calculator', BASEPLUGIN_ASSETS . '/js/calculator.js', array( 'jquery' ) );
+		wp_enqueue_script( 'produto', MELHORENVIO_ASSETS . '/js/shipping-product-page.js', array( 'jquery' ) );
+		wp_enqueue_script( 'produto-variacao', MELHORENVIO_ASSETS . '/js/shipping-product-page-variacao.js', array( 'jquery' ) );
+		wp_enqueue_script( 'calculator', MELHORENVIO_ASSETS . '/js/calculator.js', array( 'jquery' ) );
 	}
 
 	/**
@@ -83,8 +83,8 @@ class ShowCalculatorProductPage {
 	 * Adiciona o HTML do cálculo de frete na página do produto
 	 */
 	public function addCalculateShipping() {
-		wp_enqueue_style( 'calculator-style', BASEPLUGIN_ASSETS . '/css/calculator.css' );
-		wp_enqueue_script( 'calculator-script', BASEPLUGIN_ASSETS . '/js/calculator.js' );
+		wp_enqueue_style( 'calculator-style', MELHORENVIO_ASSETS . '/css/calculator.css' );
+		wp_enqueue_script( 'calculator-script', MELHORENVIO_ASSETS . '/js/calculator.js' );
 
         $allowedTags = EscapeAllowedTags::allow_tags(
             array( 'div', 'p', 'input', 'table', 'thead', 'tbody', 'small', 'img' )
@@ -100,6 +100,6 @@ class ShowCalculatorProductPage {
 	 * @return string
 	 */
 	private function getTemplateCalculator() {
-		return "<div id='woocommerce-correios-calculo-de-frete-na-pagina-do-produto' class='containerCalculator'> <?php wp_nonce_field('solicita_calculo_frete', 'solicita_calculo_frete'); ?> <input type='hidden' id='calculo_frete_endpoint_url' value='".admin_url( 'admin-ajax.php' )."'> <input type='hidden' id='calculo_frete_produto_altura' value='".$this->height."'> <input type='hidden' id='calculo_frete_produto_largura' value='".$this->width."'> <input type='hidden' id='calculo_frete_produto_comprimento' value='".$this->length."'> <input type='hidden' id='calculo_frete_produto_peso' value='".$this->weight."'> <input type='hidden' id='calculo_frete_produto_preco' value='".$this->price."'> <input type='hidden' id='id_produto' value='".$this->id."'> <div class='calculatorRow'> <div class='row'> <div class='col-75'> <p>Simulação de frete</p> <input type='text' maxlength='9' class='iptCep calculatorRow' id='inputCep' placeholder='Informe seu cep' onkeyup='usePostalCodeMask(event);'> </div> </div> <div id='calcular-frete-loader'> <img src='".BASEPLUGIN_ASSETS."/images/loader.gif' /> </div> <div class=resultado-frete tableResult> <table> <thead> </thead> <tbody> </tbody> </table> <small id='destiny-shipping-mehor-envio'></small></br> <small class='observation-shipping-free'></small> </div> </div> </div>";
+		return "<div id='woocommerce-correios-calculo-de-frete-na-pagina-do-produto' class='containerCalculator'> <?php wp_nonce_field('solicita_calculo_frete', 'solicita_calculo_frete'); ?> <input type='hidden' id='calculo_frete_endpoint_url' value='".admin_url( 'admin-ajax.php' )."'> <input type='hidden' id='calculo_frete_produto_altura' value='".$this->height."'> <input type='hidden' id='calculo_frete_produto_largura' value='".$this->width."'> <input type='hidden' id='calculo_frete_produto_comprimento' value='".$this->length."'> <input type='hidden' id='calculo_frete_produto_peso' value='".$this->weight."'> <input type='hidden' id='calculo_frete_produto_preco' value='".$this->price."'> <input type='hidden' id='id_produto' value='".$this->id."'> <div class='calculatorRow'> <div class='row'> <div class='col-75'> <p>Simulação de frete</p> <input type='text' maxlength='9' class='iptCep calculatorRow' id='inputCep' placeholder='Informe seu cep' onkeyup='usePostalCodeMask(event);'> </div> </div> <div id='calcular-frete-loader'> <img src='".MELHORENVIO_ASSETS."/images/loader.gif' /> </div> <div class=resultado-frete tableResult> <table> <thead> </thead> <tbody> </tbody> </table> <small id='destiny-shipping-mehor-envio'></small></br> <small class='observation-shipping-free'></small> </div> </div> </div>";
 	}
 }

--- a/Services/ShortCodeService.php
+++ b/Services/ShortCodeService.php
@@ -31,9 +31,9 @@ class ShortCodeService {
 	 * Adiciona o HTML do cálculo de frete na página do produto
 	 */
 	public function addCalculoDeFrete() {
-		wp_enqueue_script( 'produto-shortcode', BASEPLUGIN_ASSETS . '/js/shipping-product-page-shortcode.js', 'jquery' );
-		wp_enqueue_style( 'calculator-style', BASEPLUGIN_ASSETS . '/css/calculator.css' );
-		wp_enqueue_script( 'calculator-script', BASEPLUGIN_ASSETS . '/js/calculator.js' );
+		wp_enqueue_script( 'produto-shortcode', MELHORENVIO_ASSETS . '/js/shipping-product-page-shortcode.js', 'jquery' );
+		wp_enqueue_style( 'calculator-style', MELHORENVIO_ASSETS . '/css/calculator.css' );
+		wp_enqueue_script( 'calculator-script', MELHORENVIO_ASSETS . '/js/calculator.js' );
 
 		echo wp_kses(
 			sprintf(
@@ -79,7 +79,7 @@ class ShortCodeService {
 				$this->product->get_id(),
 				admin_url( 'admin-ajax.php' ),
 				'return usePostalCodeMask()',
-				BASEPLUGIN_ASSETS
+				MELHORENVIO_ASSETS
 			),
 			EscapeAllowedTags::allow_tags(
 				array( 'form', 'div', 'p', 'input', 'table', 'thead', 'tbody', 'tr', 'td', 'small', 'img', 'style' )

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -63,9 +63,9 @@ class Admin
 	 */
 	public function enqueue_scripts()
 	{
-		wp_enqueue_style('baseplugin-style');
-		wp_enqueue_style('baseplugin-admin');
-		wp_enqueue_script('baseplugin-admin');
+		wp_enqueue_style('melhorenvio-style');
+		wp_enqueue_style('melhorenvio-admin');
+		wp_enqueue_script('melhorenvio-admin');
 	}
 
 	/**

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -38,7 +38,7 @@ class Assets {
 		foreach ( $scripts as $handle => $script ) {
 			$deps      = isset( $script['deps'] ) ? $script['deps'] : false;
 			$in_footer = isset( $script['in_footer'] ) ? $script['in_footer'] : false;
-			$version   = isset( $script['version'] ) ? $script['version'] : BASEPLUGIN_VERSION;
+			$version   = isset( $script['version'] ) ? $script['version'] : MELHORENVIO_VERSION;
 
 			wp_register_script( $handle, $script['src'], $deps, $version, $in_footer );
 		}
@@ -55,7 +55,7 @@ class Assets {
 		foreach ( $styles as $handle => $style ) {
 			$deps = isset( $style['deps'] ) ? $style['deps'] : false;
 
-			wp_register_style( $handle, $style['src'], $deps, BASEPLUGIN_VERSION );
+			wp_register_style( $handle, $style['src'], $deps, MELHORENVIO_VERSION );
 		}
 	}
 
@@ -68,8 +68,8 @@ class Assets {
 		$prefix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.min' : '';
 
 		$scripts = array(
-			'baseplugin-admin' => array(
-				'src'       => BASEPLUGIN_ASSETS . '/js/admin.min.js',
+			'melhorenvio-admin' => array(
+				'src'       => MELHORENVIO_ASSETS . '/js/admin.min.js',
 				'deps'      => array( 'jquery' ),
 				'in_footer' => true,
 			),
@@ -86,11 +86,11 @@ class Assets {
 	public function get_styles() {
 
 		$styles = array(
-			'baseplugin-style' => array(
-				'src' => BASEPLUGIN_ASSETS . '/css/style.css',
+			'melhorenvio-style' => array(
+				'src' => MELHORENVIO_ASSETS . '/css/style.css',
 			),
-			'baseplugin-admin' => array(
-				'src' => BASEPLUGIN_ASSETS . '/css/admin.css',
+			'melhorenvio-admin' => array(
+				'src' => MELHORENVIO_ASSETS . '/css/admin.css',
 			),
 		);
 

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -19,8 +19,8 @@ class Frontend {
 	 * @return string
 	 */
 	public function render_frontend( $atts, $content = '' ) {
-		wp_enqueue_style( 'baseplugin-frontend' );
-		wp_enqueue_script( 'baseplugin-frontend' );
+		wp_enqueue_style( 'melhorenvio-frontend' );
+		wp_enqueue_script( 'melhorenvio-frontend' );
 
 		$content .= '<div id="vue-frontend-app"></div>';
 

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -1,7 +1,4 @@
 <?php
-
-require __DIR__ . '/vendor/autoload.php';
-
 /*
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
@@ -49,6 +46,8 @@ Domain Path: /languages
 if (!defined('ABSPATH')) {
     define('ABSPATH', dirname(__FILE__));
 }
+
+require_once __DIR__ . '/vendor/autoload.php';
 
 use MelhorEnvio\Controllers\ShowCalculatorProductPage;
 use MelhorEnvio\Models\CalculatorShow;
@@ -277,7 +276,7 @@ final class Base_Plugin
         add_filter( 'safe_style_css', function( $styles ) {
             $styles[] = 'display';
             return $styles;
-        } );        
+        } );
 
         add_filter('woocommerce_shipping_methods', function ($methods) {
             $methods['melhorenvio_correios_pac']  = 'WC_Melhor_Envio_Shipping_Correios_Pac';
@@ -313,13 +312,13 @@ final class Base_Plugin
 
         function load_var_nonce()
         {
-            $wpApiSettings = json_encode( array( 
+            $wpApiSettings = json_encode( array(
                 'nonce_configs' => wp_create_nonce( 'save_configurations' ),
                 'nonce_orders' => wp_create_nonce( 'orders' ),
                 'nonce_tokens' => wp_create_nonce( 'tokens' ),
                 'nonce_users' => wp_create_nonce( 'users' ),
             ) );
-            
+
             wp_register_script( 'wp-nonce-melhor-evio-wp-api', '' );
             wp_enqueue_script( 'wp-nonce-melhor-evio-wp-api' );
             wp_add_inline_script( 'wp-nonce-melhor-evio-wp-api', "var wpApiSettingsMelhorEnvio = ${wpApiSettings};" );

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -43,9 +43,7 @@ Domain Path: /languages
  */
 
 // don't call the file directly
-if (!defined('ABSPATH')) {
-    define('ABSPATH', dirname(__FILE__));
-}
+if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -8,7 +8,7 @@ Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: baseplugin
+Text Domain: melhor-envio
 Tested up to: 6.0
 Requires PHP: 7.2
 WC requires at least: 4.0
@@ -17,7 +17,7 @@ Domain Path: /languages
 */
 
 /**
- * Copyright (c) YEAR Your Name (email: Email). All rights reserved.
+ * Copyright (c) 2022 Melhor Envio. All rights reserved.
  *
  * Released under the GPL license
  * http://www.opensource.org/licenses/gpl-license.php
@@ -72,11 +72,11 @@ use MelhorEnvio\Helpers\SessionHelper;
 use MelhorEnvio\Helpers\EscapeAllowedTags;
 
 /**
- * Base_Plugin class
+ * Melhor_Envio_Plugin class
  *
- * @class Base_Plugin The class that holds the entire Base_Plugin plugin
+ * @class Melhor_Envio_Plugin The class that starts the plugin
  */
-final class Base_Plugin
+final class Melhor_Envio_Plugin
 {
     /**
      * Plugin version
@@ -93,7 +93,7 @@ final class Base_Plugin
     private $container = array();
 
     /**
-     * Constructor for the Base_Plugin class
+     * Constructor for the Melhor_Envio_Plugin class
      *
      * Sets up all the appropriate hooks and actions
      * within our plugin.
@@ -110,9 +110,9 @@ final class Base_Plugin
     }
 
     /**
-     * Initializes the Base_Plugin() class
+     * Initializes the Melhor_Envio_Plugin() class
      *
-     * Checks for an existing Base_Plugin() instance
+     * Checks for an existing Melhor_Envio_Plugin() instance
      * and if it doesn't find one, creates it.
      */
     public static function init()
@@ -121,7 +121,7 @@ final class Base_Plugin
         static $instance = false;
 
         if (!$instance) {
-            $instance = new Base_Plugin();
+            $instance = new self();
         }
 
         return $instance;
@@ -162,12 +162,12 @@ final class Base_Plugin
      */
     public function define_constants()
     {
-        define('BASEPLUGIN_VERSION', $this->version);
-        define('BASEPLUGIN_FILE', __FILE__);
-        define('BASEPLUGIN_PATH', dirname(BASEPLUGIN_FILE));
-        define('BASEPLUGIN_INCLUDES', BASEPLUGIN_PATH . '/includes');
-        define('BASEPLUGIN_URL', plugins_url('', BASEPLUGIN_FILE));
-        define('BASEPLUGIN_ASSETS', BASEPLUGIN_URL . '/assets');
+        define('MELHORENVIO_VERSION', $this->version);
+        define('MELHORENVIO_FILE', __FILE__);
+        define('MELHORENVIO_PATH', dirname(MELHORENVIO_FILE));
+        define('MELHORENVIO_INCLUDES', MELHORENVIO_PATH . '/includes');
+        define('MELHORENVIO_URL', plugins_url('', MELHORENVIO_FILE));
+        define('MELHORENVIO_ASSETS', MELHORENVIO_URL . '/assets');
     }
 
     /**
@@ -202,13 +202,13 @@ final class Base_Plugin
      */
     public function activate()
     {
-        $installed = get_option('baseplugin_installed');
+        $installed = get_option('melhorenvio_installed');
 
         if (!$installed) {
-            update_option('baseplugin_installed', time());
+            update_option('melhorenvio_installed', time());
         }
 
-        update_option('baseplugin_version', BASEPLUGIN_VERSION);
+        update_option('melhorenvio_version', MELHORENVIO_VERSION);
 
         (new ClearDataStored())->clear();
     }
@@ -221,18 +221,18 @@ final class Base_Plugin
     public function includes()
     {
         try {
-            require_once BASEPLUGIN_INCLUDES . '/class-assets.php';
+            require_once MELHORENVIO_INCLUDES . '/class-assets.php';
 
             if ($this->is_request('admin')) {
-                require_once BASEPLUGIN_INCLUDES . '/class-admin.php';
+                require_once MELHORENVIO_INCLUDES . '/class-admin.php';
             }
 
             if ($this->is_request('frontend')) {
-                require_once BASEPLUGIN_INCLUDES . '/class-frontend.php';
+                require_once MELHORENVIO_INCLUDES . '/class-frontend.php';
             }
 
             if ($this->is_request('rest')) {
-                require_once BASEPLUGIN_INCLUDES . '/class-rest-api.php';
+                require_once MELHORENVIO_INCLUDES . '/class-rest-api.php';
             }
         } catch (\Exception $e) {
             add_action('admin_notices', function ($e) {
@@ -374,7 +374,7 @@ final class Base_Plugin
      */
     public function localization_setup()
     {
-        load_plugin_textdomain('baseplugin', false, dirname(plugin_basename(__FILE__)) . '/languages/');
+        load_plugin_textdomain('melhor-envio', false, dirname(plugin_basename(__FILE__)) . '/languages/');
     }
 
     /**
@@ -403,6 +403,6 @@ final class Base_Plugin
                 return (!is_admin() || defined('DOING_AJAX')) && !defined('DOING_CRON');
         }
     }
-} // Base_Plugin
+} // Melhor_Envio_Plugin
 
-$baseplugin = Base_Plugin::init();
+Melhor_Envio_Plugin::init();

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -45,6 +45,16 @@ Domain Path: /languages
 // don't call the file directly
 if (!defined('ABSPATH')) exit;
 
+// check if the composer packages are installed
+if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+    add_action( 'admin_notices', function () {
+        $class = 'notice notice-error';
+        $message = 'Erro ao ativar o plugin da Melhor Envio: a pasta <code>vendor</code> não foi localizada no plugin.';
+        printf( '<div class="%1$s"><p>%2$s</p></div>', $class, $message );
+    } );
+    return false;
+}
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 use MelhorEnvio\Controllers\ShowCalculatorProductPage;
@@ -60,15 +70,6 @@ use MelhorEnvio\Services\ListPluginsIncompatiblesService;
 use MelhorEnvio\Services\SessionNoticeService;
 use MelhorEnvio\Helpers\SessionHelper;
 use MelhorEnvio\Helpers\EscapeAllowedTags;
-
-if (!file_exists(plugin_dir_path(__FILE__) . '/vendor/autoload.php')) {
-    $message = 'Erro ao ativar o plugin da Melhor Envio, não localizada a vendor do plugin';
-    (new SessionNoticeService())->add(
-        'Erro ao ativar o plugin da Melhor Envio, não localizada a vendor do plugin',
-        'notice-error'
-    );
-    return false;
-}
 
 /**
  * Base_Plugin class


### PR DESCRIPTION
- Carrega o `autoload.php` somente depois de verificar se a pasta `vendor` existe.
- Troca "Base Plugin" para "Melhor Envio Plugin". A palavra "base plugin" nem deveria estar no código, pois provavelmente é um vestigio do boilerplate que foi usado no desenvolvimento inicial. O maior problema é que outro desenvolvedor pode cometer o mesmo erro e lançar um plugin com "base plugin" e causar conflito em várias lojas.