### PR TITLE
fix: adjust to set quantity 1 when not has quantity

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -4,5 +4,5 @@ namespace MelhorEnvio\Models;
 
 class Version {
 
-	const VERSION = '2.11.29';
+	const VERSION = '2.11.30';
 }

--- a/Services/QuotationProductPageService.php
+++ b/Services/QuotationProductPageService.php
@@ -116,10 +116,7 @@ class QuotationProductPageService {
 		}
 
 		if ( ! is_int( $this->quantity ) || $this->quantity == 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'É necessário informar uma quantidade válida',
-			);
+			$this->quantity = 1;
 		}
 
 		if ( ! empty( $this->destination ) ) {

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -6,7 +6,7 @@ require __DIR__ . '/vendor/autoload.php';
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.11.29
+Version: 2.11.30
 Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.11.29
+Version: 2.11.30
 Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam cargo, azul, azul cargo express, melhor envio
 Requires at least: 4.7
 Tested up to: 6.0
-Stable tag: 2.11.29
+Stable tag: 2.11.30
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+


### PR DESCRIPTION
Se aplicado, esse PR irá resolver o problema que acontece em alguns temas do WordPress quando não existe o campo quantity do produto na tela do produto.