### PR TITLE
feat: atualiza o endpoint da api de ceps

### DIFF
--- a/Services/LocationService.php
+++ b/Services/LocationService.php
@@ -10,7 +10,7 @@ class LocationService {
 	/**
 	 * Melhor Envio location api URL
 	 */
-	const URL = 'https://location.melhorenvio.com.br/';
+	const URL = 'http://location.melhorenvio.com/';
 
 	/**
 	 * Via CEP location api URL


### PR DESCRIPTION
- Configura o domínio .com para centralizarmos nesse domínio (.br vai seguir funcionando por um tempo).
- Remove o SSL (https) para a requisição não realizar a validação de SSL, que aumenta o tempo de resposta, uma vez que a api não trafega dados sensíveis.
- Exemplo: http://location.melhorenvio.com/01028020