### PR TITLE
fix: solve problem price on combo products

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -4,5 +4,5 @@ namespace MelhorEnvio\Models;
 
 class Version {
 
-	const VERSION = '2.11.34';
+	const VERSION = '2.11.35';
 }

--- a/Services/CompositeProductBundleService.php
+++ b/Services/CompositeProductBundleService.php
@@ -23,6 +23,8 @@ class CompositeProductBundleService {
 
 	const PRODUCT_COMPOSITE = 'WC_Product_Composite';
 
+	const PRODUCT_COMBO_OFFICER = 'WC_Product_Wooco';
+
 	const PRODUCT_COMPOSITE_SHIPPING_FEE = 'wooco_shipping_fee';
 
 	const PRODUCT_COMPOSITE_PRICING = 'wooco_pricing';

--- a/Services/OrdersProductsService.php
+++ b/Services/OrdersProductsService.php
@@ -62,7 +62,7 @@ class OrdersProductsService {
 			}
 
 			$product = $itemProduct->get_product();
-			if ( is_bool( $product ) || get_class( $product ) === CompositeProductBundleService::PRODUCT_COMPOSITE ) {
+			if ( is_bool( $product ) || get_class( $product ) === CompositeProductBundleService::PRODUCT_COMPOSITE || get_class( $product ) === CompositeProductBundleService::PRODUCT_COMBO_OFFICER ) {
 				$compositeBundleService = new CompositeProductBundleService( $itemProduct );
 				$productComposite       = $compositeBundleService->getProductNormalize();
 
@@ -81,7 +81,16 @@ class OrdersProductsService {
 					$itemProduct->get_quantity()
 				);
 
-				$price = (float) $itemProduct->get_data()['total'] / $itemProduct->get_data()['quantity'];
+				$quantityInsiderItem = 1;
+				if (isset($itemProduct->get_data()['quantity'])) {
+					$quantityInsiderItem = $itemProduct->get_data()['quantity'];
+				}
+				
+				$price = (float) $itemProduct->get_data()['total'] / $quantityInsiderItem;
+				if ($price == 0) {
+					continue;
+				}
+
 				$products[$productId]->insurance_value = $price;
 				$products[$productId]->unitary_value = $price;
 				$quantities = $this->incrementQuantity(

--- a/Services/OrdersProductsService.php
+++ b/Services/OrdersProductsService.php
@@ -118,9 +118,9 @@ class OrdersProductsService {
 
 	public function isComboProduct($product)
 	{
-		return is_bool( $product ) ||
-			get_class( $product ) === CompositeProductBundleService::PRODUCT_COMPOSITE ||
-			get_class( $product ) === CompositeProductBundleService::PRODUCT_COMBO_OFFICER;
+		return is_bool($product) ||
+			get_class($product) === CompositeProductBundleService::PRODUCT_COMPOSITE ||
+			get_class($product) === CompositeProductBundleService::PRODUCT_COMBO_OFFICER;
 	}
 
 	/**

--- a/Services/OrdersProductsService.php
+++ b/Services/OrdersProductsService.php
@@ -62,10 +62,9 @@ class OrdersProductsService {
 			}
 
 			$product = $itemProduct->get_product();
-			if ( is_bool( $product ) || get_class( $product ) === CompositeProductBundleService::PRODUCT_COMPOSITE || get_class( $product ) === CompositeProductBundleService::PRODUCT_COMBO_OFFICER ) {
+			if ($this->isComboProduct($product)) {
 				$compositeBundleService = new CompositeProductBundleService( $itemProduct );
-				$productComposite       = $compositeBundleService->getProductNormalize();
-
+				$productComposite = $compositeBundleService->getProductNormalize();
 				if ( empty( $productComposite ) ) {
 					continue;
 				}
@@ -115,6 +114,13 @@ class OrdersProductsService {
 		}
 
 		return $products;
+	}
+
+	public function isComboProduct($product)
+	{
+		return is_bool( $product ) ||
+			get_class( $product ) === CompositeProductBundleService::PRODUCT_COMPOSITE ||
+			get_class( $product ) === CompositeProductBundleService::PRODUCT_COMBO_OFFICER;
 	}
 
 	/**

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,7 +3,7 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.11.34
+Version: 2.11.35
 Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.11.34
+Version: 2.11.35
 Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam cargo, azul, azul cargo express, melhor envio
 Requires at least: 4.7
 Tested up to: 6.0
-Stable tag: 2.11.34
+Stable tag: 2.11.35
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -64,6 +64,9 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+= 2.11.35 =
+* Correção para aplicar o valor do produto para produtos combos.
+
 = 2.11.34 =
 * Correção para utilizar o valor do produto com cupom de desconto aplicado no campo de valor segurado.
 


### PR DESCRIPTION
# Descrição

Se aplicado, esse PR irá resolver o problema de enviar um pedido para o carrinho do melhor envio, onde o pedido foi um produto do tipo combo e era informado que o produto não possuía valor unitário. 

https://melhorenvio.atlassian.net/browse/SMS-1935