### PR TITLE
replaces the deprecated woocommerce_my_account_my_orders_columns hook

### DIFF
--- a/Services/TrackingService.php
+++ b/Services/TrackingService.php
@@ -73,7 +73,7 @@ class TrackingService {
 	 */
 	public function createTrackingColumnOrdersClient() {
 		add_filter(
-			'woocommerce_my_account_my_orders_columns',
+			'woocommerce_account_orders_columns',
 			function ( $columns ) {
 				$newColumns = array();
 				foreach ( $columns as $key => $name ) {


### PR DESCRIPTION
The woocommerce_my_account_my_orders_columns hook used in /Services/TrackingService.php is deprecated since version 2.6.0. woocommerce_account_orders_columns should be used instead.