### PR TITLE
feat: adiciona plugins requiridos

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -4,5 +4,5 @@ namespace MelhorEnvio\Models;
 
 class Version {
 
-	const VERSION = '2.15.3';
+	const VERSION = '2.15.4';
 }

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -9,6 +9,7 @@ Author URI: melhorenvio.com.br
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: melhor-envio
+Requires Plugins: woocommerce, woocommerce-extra-checkout-fields-for-brazil
 Tested up to: 6.5
 Requires PHP: 7.2
 WC requires at least: 4.0

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,7 +3,7 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.15.3
+Version: 2.15.4
 Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.15.3
+Version: 2.15.4
 Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam cargo, azul, azul cargo express, melhor envio
 Requires at least: 4.7
 Tested up to: 6.5
-Stable tag: 2.15.3
+Stable tag: 2.15.4
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+


### PR DESCRIPTION
Com esse PR os usuários que baixarem o plugin só conseguirão ativar o plugin depois de ter os plugins **WooCommerce** e **Brazilian Market on WooCommerce** ativos também, já que o plugin ME depende destes para funcionar corretamente.