### PR TITLE
fix: Corrige reatividade do componente

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -4,5 +4,5 @@ namespace MelhorEnvio\Models;
 
 class Version {
 
-	const VERSION = '2.15.4';
+	const VERSION = '2.15.5';
 }

--- a/assets/src/admin/components/Pedidos.vue
+++ b/assets/src/admin/components/Pedidos.vue
@@ -358,12 +358,9 @@ export default {
     ordersWithValidationProducts() {
       return this.orders.map((order) => {
         const products = Object.values(order.products);
-        const existInvalidProduct = products.some(product => product["type"] === 'invalid');
-        return {
-          ...order,
-          existInvalidProduct,
-          products
-        };
+        order.existInvalidProduct = products.some(product => product.type === 'invalid');
+
+        return order;
       });
     }
   },

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,7 +3,7 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.15.4
+Version: 2.15.5
 Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.15.4
+Version: 2.15.5
 Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam cargo, azul, azul cargo express, melhor envio
 Requires at least: 4.7
 Tested up to: 6.5
-Stable tag: 2.15.4
+Stable tag: 2.15.5
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -68,6 +68,13 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+= 2.15.5 =
+* Corrige reatividade na adição dos dados de NF.
+
+= 2.15.4 =
+* Adiciona plugins requiridos pelo ME.
+* Adiciona tratativas para produtos excluídos.
+
 = 2.15.3 =
 * Corrige lentidão no checkout.
 


### PR DESCRIPTION
Na versão 2.15.4 do plugin foi adicionado uma função no código que alterava o objeto `orders`, com isso o componente onde preenche os dados de **Nota Fiscal** perdeu a reatividade, portanto não era possível adicionar tais dados. Esse PR corrige isso.