### PR TITLE
fix: corrige cotação para pedidos com produtos virtuais

### DIFF
--- a/Services/CalculateShippingMethodService.php
+++ b/Services/CalculateShippingMethodService.php
@@ -4,6 +4,7 @@ namespace MelhorEnvio\Services;
 
 use Exception;
 use MelhorEnvio\Helpers\MoneyHelper;
+use MelhorEnvio\Helpers\ProductVirtualHelper;
 use MelhorEnvio\Helpers\TimeHelper;
 use MelhorEnvio\Models\ShippingService;
 use MelhorEnvio\Helpers\PostalCodeHelper;
@@ -47,6 +48,8 @@ class CalculateShippingMethodService {
 		}
 
 		$products = ( new CartWooCommerceService() )->getProducts();
+
+        $products = ProductVirtualHelper::removeVirtuals( $products );
 
 		if ( empty( $products ) ) {
 			$products = $package['contents'];

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Pronto! o plugin do Melhor Envio está funcionando.
 == Changelog ==
 = 2.15.8 =
 * Adiciona log no caso de falha em uma requisição.
+* Corrige cotacao em compras com produtos virtuais.
 
 = 2.15.7 =
 * Corrige problema na busca do CEP.


### PR DESCRIPTION
No carrinho do cliente, quando havia um produto virtual ( produto que não será enviado ), esse produto era considerado na cotação, como ele não tinha medidas cadastradas as medidas padrões eram preenchidas para ele e enfim era feito a cotação.
Esse PR faz com que esses produtos não sejam preenchidos no payload da cotação, assim como já acontece em outros lugares do plugin.  