### PR TITLE
fix: adiciona validação quando o CEP é somente zeros 

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -4,5 +4,5 @@ namespace MelhorEnvio\Models;
 
 class Version {
 
-	const VERSION = '2.15.8';
+	const VERSION = '2.15.9';
 }

--- a/Services/PayloadService.php
+++ b/Services/PayloadService.php
@@ -197,6 +197,10 @@ class PayloadService {
 			return false;
 		}
 
+        if ($from == '00000000') {
+            return false;
+        }
+
 		if ( empty( $payload->to ) || empty( $payload->to->postal_code ) ) {
 			return false;
 		}
@@ -205,6 +209,10 @@ class PayloadService {
 		if ( strlen( $to ) != PostalCodeHelper::SIZE_POSTAL_CODE ) {
 			return false;
 		}
+
+        if ($to == '00000000') {
+            return false;
+        }
 
 		if ( empty( $payload->options ) ) {
 			return false;

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,14 +3,14 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.15.8
+Version: 2.15.9
 Author: Melhor Envio
 Author URI: melhorenvio.com.br
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: melhor-envio
 Requires Plugins: woocommerce, woocommerce-extra-checkout-fields-for-brazil
-Tested up to: 6.5
+Tested up to: 6.6
 Requires PHP: 7.2
 WC requires at least: 4.0
 WC tested up to: 8.8

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.15.8
+Version: 2.15.9
 Tags: frete, fretes, cotação, cotações, correios, envio, jadlog, latam latam cargo, azul, azul cargo express, melhor envio
 Requires at least: 4.7
-Tested up to: 6.5
-Stable tag: 2.15.8
+Tested up to: 6.6
+Stable tag: 2.15.9
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -68,6 +68,10 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+= 2.15.9 =
+* Adiciona validacao quando o cep é somente zeros.
+* Atualiza versão compativel do wordpress.
+
 = 2.15.8 =
 * Adiciona log no caso de falha em uma requisição.
 * Corrige cotacao em compras com produtos virtuais.


### PR DESCRIPTION
Hoje, quando o consumidor final acessa a loja do seller (nosso cliente - o lojista), dentro da tela de um produto ele consegue efetuar uma cotação para determinar o valor do frete, porém no WooCommerce é feita uma requisição automática no carregamento da página, ainda sem o CEP de origem preenchido, enviando-o como `00000000`, fazendo com que a requisição falhe. Após o preenchimento do CEP pelo consumidor final, a request é processada normalmente com sucesso. 

Visando evitar a requisição com falha e o log de erro, este PR força a validação da request a falhar, evitando que a mesma seja feita neste contexto.

Não é um problema que afetava a usabilidade do plugin, porém com isso a gente faz muitas requisições desnecessárias para a rota de cotação que acaba retornando 422 para essa requisição, na versão 2.15.8 adicionamos o log para quando uma requisição falha, dessa portanto se não pararmos de fazer essas requisições com o payload errado, vamos encher os arquivos de logs com requisições inúteis.