### PR TITLE
fix: para de considerar o carrinho ao fazer cálculo na página de produto

### DIFF
--- a/Models/Version.php
+++ b/Models/Version.php
@@ -3,5 +3,5 @@
 namespace MelhorEnvio\Models;
 
 class Version {
-	const VERSION = '2.15.14';
+	const VERSION = '2.15.16';
 }

--- a/Services/CalculateShippingMethodService.php
+++ b/Services/CalculateShippingMethodService.php
@@ -47,7 +47,9 @@ class CalculateShippingMethodService {
 			return false;
 		}
 
-		$products = ( new CartWooCommerceService() )->getProducts();
+		if(!$this->isProductPageCalculation($package)){
+			$products = ( new CartWooCommerceService() )->getProducts();
+		}
 
         $products = ProductVirtualHelper::removeVirtuals( $products );
 
@@ -297,5 +299,11 @@ class CalculateShippingMethodService {
 		}
 
 		return $optionalInsuredAmount;
+	}
+
+	private function isProductPageCalculation($package)
+	{
+		return isset($package['product_page_calculation']) 
+			&& $package['product_page_calculation'] == true;
 	}
 }

--- a/Services/CalculateShippingMethodService.php
+++ b/Services/CalculateShippingMethodService.php
@@ -3,6 +3,7 @@
 namespace MelhorEnvio\Services;
 
 use Exception;
+use MelhorEnvio\Factory\ProductServiceFactory;
 use MelhorEnvio\Helpers\MoneyHelper;
 use MelhorEnvio\Helpers\ProductVirtualHelper;
 use MelhorEnvio\Helpers\TimeHelper;
@@ -47,15 +48,17 @@ class CalculateShippingMethodService {
 			return false;
 		}
 
+        $products = [];
+
 		if(!$this->isProductPageCalculation($package)){
 			$products = ( new CartWooCommerceService() )->getProducts();
 		}
 
-        $products = ProductVirtualHelper::removeVirtuals( $products );
-
 		if ( empty( $products ) ) {
 			$products = $package['contents'];
 		}
+
+        $products = ProductVirtualHelper::removeVirtuals( $products );
 
 		$result = ( new QuotationService() )->calculateQuotationByProducts(
 			$products,
@@ -247,15 +250,15 @@ class CalculateShippingMethodService {
 			return $show;
 		}
 
-		foreach ( $package['contents'] as $values ) {
-			$product = $values['data'];
-			$qty     = $values['quantity'];
-			if ( $qty > 0 && $product->needs_shipping() ) {
-				if ( $this->isProductWithouShippingClass( $product->get_shipping_class_id(), $shippingClassId ) ) {
+		foreach ( $package['contents'] as $product ) {
+            $wcProduct = wc_get_product( $product->id );
+
+			if ( $product->quantity > 0 && $wcProduct->needs_shipping() ) {
+				if ( $this->isProductWithouShippingClass( $wcProduct->get_shipping_class_id(), $shippingClassId ) ) {
 					$show = true;
 					break;
 				}
-				$show = ( $product->get_shipping_class_id() == $shippingClassId );
+				$show = ( $wcProduct->get_shipping_class_id() == $shippingClassId );
 			}
 		}
 
@@ -303,7 +306,7 @@ class CalculateShippingMethodService {
 
 	private function isProductPageCalculation($package)
 	{
-		return isset($package['product_page_calculation']) 
+		return isset($package['product_page_calculation'])
 			&& $package['product_page_calculation'] == true;
 	}
 }

--- a/Services/CalculateShippingMethodService.php
+++ b/Services/CalculateShippingMethodService.php
@@ -251,9 +251,10 @@ class CalculateShippingMethodService {
 		}
 
 		foreach ( $package['contents'] as $product ) {
-            $wcProduct = wc_get_product( $product->id );
+            $quantity = $product->quantity ?? $product['quantity'];
+            $wcProduct = $product->id ? wc_get_product( $product->id ) : $product['data'];
 
-			if ( $product->quantity > 0 && $wcProduct->needs_shipping() ) {
+			if ( $quantity > 0 && $wcProduct->needs_shipping() ) {
 				if ( $this->isProductWithouShippingClass( $wcProduct->get_shipping_class_id(), $shippingClassId ) ) {
 					$show = true;
 					break;

--- a/Services/QuotationProductPageService.php
+++ b/Services/QuotationProductPageService.php
@@ -186,6 +186,7 @@ class QuotationProductPageService {
 			),
 			'contents'      => $contents,
 			'contents_cost' => $this->product->get_price() * $this->quantity,
+			'product_page_calculation' => true,
 		);
 	}
 

--- a/Services/QuotationProductPageService.php
+++ b/Services/QuotationProductPageService.php
@@ -2,6 +2,7 @@
 
 namespace MelhorEnvio\Services;
 
+use MelhorEnvio\Factory\ProductServiceFactory;
 use MelhorEnvio\Helpers\MoneyHelper;
 use MelhorEnvio\Helpers\PostalCodeHelper;
 use MelhorEnvio\Services\Products\ProductsService;
@@ -170,12 +171,7 @@ class QuotationProductPageService {
 	 * @return void
 	 */
 	private function createPackageToCalculate() {
-		$contents = array();
-
-		$contents[ $this->product->get_id() ] = array(
-			'data'     => $this->product,
-			'quantity' => $this->quantity,
-		);
+        $productService = ProductServiceFactory::fromId($this->product->get_id());
 
 		$this->package = array(
 			'ship_via'      => '',
@@ -184,7 +180,9 @@ class QuotationProductPageService {
 				'state'    => ( ! empty( $this->destination->uf ) ) ? $this->destination->uf : null,
 				'postcode' => ( ! empty( $this->destination->cep ) ) ? $this->destination->cep : $this->postalCode,
 			),
-			'contents'      => $contents,
+			'contents'      => [
+                $productService->getProduct($this->product->get_id(), $this->quantity)
+            ],
 			'contents_cost' => $this->product->get_price() * $this->quantity,
 			'product_page_calculation' => true,
 		);

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,7 +3,7 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.15.14
+Version: 2.15.16
 Author: Melhor Envio
 Author URI: https://melhorenvio.com.br
 License: GPLv3

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.15.14
+Version: 2.15.16
 Tags: frete, cotação, logística, envio, melhor envio
 Requires at least: 4.7
 Tested up to: 6.8
-Stable tag: 2.15.14
+Stable tag: 2.15.16
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -68,6 +68,12 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+
+= 2.15.16 =
+* Corrige cotação na página do produto
+
+= 2.15.15 =
+* Corrige formatação de valor do produto para duas casas decimais
 
 = 2.15.14 =
 * Busca agencias usando latitude e longitude


### PR DESCRIPTION
O cálculo de frete disponível nas páginas de produto está considerando o carrinho atual ao invés de somente considerar o produto sendo exibido na página, portanto esse PR corrige esse comportamento.