### PR TITLE
feat: usa longitude e latitude para buscar agencias

### DIFF
--- a/Controllers/AgenciesController.php
+++ b/Controllers/AgenciesController.php
@@ -18,10 +18,10 @@ class AgenciesController {
 
 			WpNonceValidatorHelper::check( $_GET['_wpnonce'], 'save_configurations' );
 
-			if ( empty( $_GET['state'] ) ) {
+			if ( empty( $_GET['state'] ) && (empty( $_GET['latitude'] ) && empty( $_GET['longitude'] )) ) {
 				return wp_send_json(
 					array(
-						'message' => 'É necessário informar o estado para reallizar a busca de agências',
+						'message' => 'É necessário informar o estado ou a latitude e longitude para reallizar a busca de agências',
 					),
 					400
 				);

--- a/Models/Address.php
+++ b/Models/Address.php
@@ -56,6 +56,8 @@ class Address {
 				'city'        => $address->city->city,
 				'state'       => $address->city->state->state_abbr,
 				'country'     => $address->city->state->country->id,
+				'latitude'    => $address->latitude,
+				'longitude'   => $address->longitude,
 				'selected'    => ( $selectedAddress == $address->id ),
 			);
 		}

--- a/Models/Version.php
+++ b/Models/Version.php
@@ -3,5 +3,5 @@
 namespace MelhorEnvio\Models;
 
 class Version {
-	const VERSION = '2.15.13';
+	const VERSION = '2.15.14';
 }

--- a/Services/AgenciesService.php
+++ b/Services/AgenciesService.php
@@ -16,10 +16,25 @@ class AgenciesService {
 
 	protected $service = null;
 
-	public function __construct( $data ) {
+	protected $latitude = null;
 
+	protected $longitude = null;
+
+	protected $distanceSearch = 100000;
+
+	protected $limit = 100;
+
+	protected $country = 'BR';
+
+	protected $status = 'available';
+
+	public function __construct( $data ) {
 		if ( ! empty( $data['state'] ) ) {
 			$this->state = $data['state'];
+		}
+
+		if ( ! empty( $data['city'] ) ) {
+			$this->city = $data['city'];
 		}
 
 		if ( ! empty( $data['company'] ) ) {
@@ -28,6 +43,13 @@ class AgenciesService {
 
 		if ( ! empty( $data['serviceId'] ) ) {
 			$this->service = $data['serviceId'];
+		}
+
+		if ( ! empty( $data['latitude'] ) && ! empty( $data['longitude'] ) ) {
+			$this->latitude = $data['latitude'];
+			$this->longitude = $data['longitude'];
+			$this->state = null;
+			$this->city = null;
 		}
 	}
 
@@ -60,10 +82,20 @@ class AgenciesService {
 	 * @return string $route
 	 */
 	private function getRoute() {
-		$data['country'] = 'BR';
+		$data['status'] = $this->status;
+		$data['country'] = $this->country;		
+		$data['limit'] = $this->limit;
+
+		if ( ! empty( $this->distanceSearch ) ) {
+			$data['distanceSearch'] = $this->distanceSearch;
+		}
 
 		if ( ! empty( $this->state ) ) {
 			$data['state'] = $this->state;
+		}
+
+		if ( ! empty( $this->city ) ) {
+			$data['city'] = $this->city;
 		}
 
 		if ( ! empty( $this->company ) ) {
@@ -72,6 +104,13 @@ class AgenciesService {
 
 		if ( ! empty( $this->service ) ) {
 			$data['serviceId'] = $this->service;
+		}
+
+		if ( ! empty( $this->latitude ) && ! empty( $this->longitude ) ) {
+			$data['latitude'] = $this->latitude;
+			$data['longitude'] = $this->longitude;
+			unset( $data['state'] );
+			unset( $data['city'] );
 		}
 
 		$query = http_build_query( $data );

--- a/Services/ConfigurationsService.php
+++ b/Services/ConfigurationsService.php
@@ -141,11 +141,19 @@ class ConfigurationsService {
 		$agenciesSelecteds = array();
 
 		if ( ! empty( $originselected ) ) {
-			$address           = array(
-				'state' => $originselected['address']['state'],
-				'city' => $originselected['address']['city'],
-				'company' => null,
-			);
+			if ( ! empty( $originselected['address']['latitude'] ) && ! empty( $originselected['address']['longitude'] ) ) {
+				$address = array(
+					'latitude' => $originselected['address']['latitude'],
+					'longitude' => $originselected['address']['longitude'],
+					'company' => null,
+				);
+			} else {
+				$address = array(
+					'state' => $originselected['address']['state'],
+					'city' => $originselected['address']['city'],
+					'company' => null,
+				);
+			}
 			$agencies = ( new AgenciesService( $address ) )->get();
 
 			$address['serviceId'] = ShippingService::JADLOG_PACKAGE_CENTRALIZED;
@@ -456,6 +464,8 @@ class ConfigurationsService {
 						'city'        => $address->city->city,
 						'state'       => $address->city->state->state_abbr,
 						'country'     => 'BR',
+						'latitude'    => isset( $address->latitude ) ? $address->latitude : null,
+						'longitude'   => isset( $address->longitude ) ? $address->longitude : null,
 					),
 					'selected'               => $address->id == $addressSelectedId,
 				);

--- a/assets/src/admin/components/Configuracoes.vue
+++ b/assets/src/admin/components/Configuracoes.vue
@@ -115,6 +115,8 @@
                       refreshAgencies({
                         city: option.address.city,
                         state: option.address.state,
+                        latitude: option.address.latitude || '',
+                        longitude: option.address.longitude || '',
                       }),
                         setOrigin(option.id)
                     "
@@ -879,9 +881,9 @@ export default {
         });
       }
     },
-    createAjaxUrl(companyId, data, serviceId) {
-      const { city, state } = data;
-      return `${ajaxurl}?action=get_agencies&company=${companyId}&city=${city}&state=${state}&serviceId=${serviceId}&_wpnonce=${wpApiSettingsMelhorEnvio.nonce_configs}`;
+    createAjaxUrl(companyId, data, serviceId = "") {
+      const { city, state, latitude, longitude } = data;
+      return `${ajaxurl}?action=get_agencies&company=${companyId}&city=${city}&state=${state}&latitude=${latitude}&longitude=${longitude}&serviceId=${serviceId}&_wpnonce=${wpApiSettingsMelhorEnvio.nonce_configs}`;
     },
     showJadlogAgencies(data) {
       this.setLoader(true);
@@ -889,7 +891,7 @@ export default {
       var responseAgencies = [];
       var promiseAgencies = new Promise((resolve, _reject) => {
         this.$http
-          .post(this.createAjaxUrl(2, data, null))
+          .post(this.createAjaxUrl(2, data))
           .then(function (response) {
             if (response && response.status === 200) {
               responseAgencies = response.data;
@@ -916,7 +918,7 @@ export default {
       var responseAgenciesAzul = [];
       var promiseAgencies = new Promise((resolve, _reject) => {
         this.$http
-          .post(this.createAjaxUrl(9, data, null))
+          .post(this.createAjaxUrl(9, data))
           .then(function (response) {
             if (response && response.status === 200) {
               responseAgenciesAzul = response.data;
@@ -1020,7 +1022,7 @@ export default {
       var responseAgenciesLatam = [];
       var promiseAgencies = new Promise((resolve, _reject) => {
         this.$http
-          .post(this.createAjaxUrl(6, data, null))
+          .post(this.createAjaxUrl(6, data))
           .then(function (response) {
             if (response && response.status === 200) {
               responseAgenciesLatam = response.data;
@@ -1046,7 +1048,7 @@ export default {
       var responseAgenciesJeT = [];
       var promiseAgencies = new Promise((resolve, _reject) => {
         this.$http
-          .post(this.createAjaxUrl(15, data, null))
+          .post(this.createAjaxUrl(15, data))
           .then(function (response) {
             if (response && response.status === 200) {
               responseAgenciesJeT = response.data;

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,7 +3,7 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.15.13
+Version: 2.15.14
 Author: Melhor Envio
 Author URI: https://melhorenvio.com.br
 License: GPLv3

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.15.13
+Version: 2.15.14
 Tags: frete, cotação, logística, envio, melhor envio
 Requires at least: 4.7
 Tested up to: 6.8
-Stable tag: 2.15.13
+Stable tag: 2.15.14
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -68,6 +68,9 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+
+= 2.15.14 =
+* Busca agencias usando latitude e longitude
 
 = 2.15.13 =
 * Altera tags de busca


### PR DESCRIPTION
Com esse PR a busca de agencias na configuração começa a utilizar a Latitude e Longitude do endereço selecionado pelo usuário. Caso o endereço não tenha latitude e longitude continua com o método padrão pela busca de cidade/estado. 