### PR TITLE
fix: corrige valor do produto

### DIFF
--- a/Models/Product.php
+++ b/Models/Product.php
@@ -21,7 +21,7 @@ class Product
 	public $shipping_fee;
 
 	public function setValues($value){
-		$this->unitary_value = (float) $value;
-		$this->insurance_value = (float) $value;
+		$this->unitary_value = (float) number_format($value, 2, '.', '');
+		$this->insurance_value = (float) number_format($value, 2, '.', '');
 	}
 }


### PR DESCRIPTION
Com esse PR pedidos que tenham produtos com mais de 2 casas decimais no valor param de dar erro ao serem enviados para o carrinho