### PR TITLE
Fix sql prefix table problems

### DIFF
--- a/Models/Method.php
+++ b/Models/Method.php
@@ -11,17 +11,15 @@ class Method {
 
 		$result = $wpdb->get_results(
             $wpdb->prepare(
-                'select meta_value as method 
-                 from %swoocommerce_order_itemmeta 
-                 where meta_key = "method_id" 
+                "select meta_value as method 
+                 from {$wpdb->prefix}woocommerce_order_itemmeta 
+                 where meta_key = 'method_id'
                  and order_item_id IN (
                   select order_item_id 
-                  from %swoocommerce_order_items 
+                  from {$wpdb->prefix}woocommerce_order_items 
                   where order_id = %d 
-                  and order_item_type = "shipping"
-                 )',
-                $wpdb->prefix,
-                $wpdb->prefix,
+                  and order_item_type = 'shipping'
+                 )",
                 $order_id
             )
         );
@@ -56,8 +54,8 @@ class Method {
 		$enableds = array();
 		$results  = $wpdb->get_results(
             $wpdb->prepare(
-                'select * from %swoocommerce_shipping_zone_methods where is_enabled = 1',
-                $wpdb->prefix
+                "select * from {$wpdb->prefix}woocommerce_shipping_zone_methods
+				 where is_enabled = 1"
             )
         );
 

--- a/Services/Products/BundleService.php
+++ b/Services/Products/BundleService.php
@@ -12,6 +12,10 @@ class BundleService extends ProductsService
 
 	public static function isBundleProduct($product): bool
 	{
+		if (!$product || !is_object($product)) {
+			return false;
+		}
+		
 		return $product->get_type() === self::BUNDLE_TYPE ||
 			$product->get_type() === self::PRODUCT_BUNDLE_TYPE;
 	}

--- a/Services/Products/CompositeService.php
+++ b/Services/Products/CompositeService.php
@@ -13,6 +13,10 @@ class CompositeService extends ProductsService
 
 	public static function isCompositeProduct($product): bool
 	{
+		if (!$product || !is_object($product)) {
+			return false;
+		}
+		
 		return $product->get_type() === self::COMPOSITE_TYPE ||
 			$product->get_type() === self::PRODUCT_COMPOSITE_TYPE;
 	}

--- a/Services/QuotationProductPageService.php
+++ b/Services/QuotationProductPageService.php
@@ -104,17 +104,17 @@ class QuotationProductPageService {
 	 * @return array
 	 */
 	public function getRatesShipping() {
-		if ( ProductsService::hasProductComposition($this->product) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Cotação disponível apenas no carrinho!',
-			);
-		}
-
 		if ( empty( $this->product ) ) {
 			return array(
 				'success' => false,
 				'error'   => 'Não encontramos o produto na base de dados',
+			);
+		}
+		
+		if ( ProductsService::hasProductComposition($this->product) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Cotação disponível apenas no carrinho!',
 			);
 		}
 


### PR DESCRIPTION
fix prefix
Corrigido problema de PREFIX das tabelas no sql, o PREPARE considera adicionar aspas ao substituir uma string, esta forma a inserção gera erro de sql como
from 'wp_'woocommerce , desta forma alterando o codigo para {$wpdb->prefix} que é a forma correta este problema é resolvido.
1fc1c394
Models/Method.php