### PR TITLE
fix: adiciona nova máscara para o campo CNPJ

### DIFF
--- a/assets/src/admin/components/Configuracoes.vue
+++ b/assets/src/admin/components/Configuracoes.vue
@@ -205,7 +205,7 @@
               <span>CNPJ</span></br>
               <the-mask
                 v-model="label.company_document"
-                :mask="['##.###.###/####-##']"
+                :mask="['XX.XXX.XXX/XXXX-##', '##.###.###/####-##']"
               />
               <br />
               <br />


### PR DESCRIPTION
## Contexto

A partir de **julho/2026** a Receita Federal passará a emitir **CNPJ alfanumérico** para novas inscrições (12 posições alfanuméricas + 2 dígitos verificadores). CNPJs existentes permanecem apenas numéricos. O plugin precisava permitir letras no documento da empresa nos fluxos internos e no painel sem remover caracteres alfanuméricos na normalização.

## O que mudou

- **`Configuracoes.vue`** — Máscara do campo CNPJ ampliada com duas opções (`XX.XXX.XXX/XXXX-##` e `##.###.###/####-##`) via vue-the-mask, cobrindo formato novo e legado no admin.

## Como testar

- [ ] Admin: em Configurações → informações da etiqueta, inserir CNPJ **só numérico** (ex.: `12.345.678/0001-90`) e salvar.
- [ ] Admin: inserir CNPJ **alfanumérico fictício** (ex.: `A1B2.C34.D56/7890-12`) e verificar se o valor persiste e é enviado sem pontuação onde aplicável.