### PR TITLE
fix: torna o plugin the woo-better-shipping-calculator-for-brazil opcional (#228|1408)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ composer.lock
 .idea/
 
 docker/.env
+
+.cursor/
+.specs/

--- a/Models/Version.php
+++ b/Models/Version.php
@@ -3,5 +3,5 @@
 namespace MelhorEnvio\Models;
 
 class Version {
-	const VERSION = '2.16.1';
+	const VERSION = '2.16.2';
 }

--- a/Services/CheckHealthService.php
+++ b/Services/CheckHealthService.php
@@ -55,6 +55,7 @@ class CheckHealthService {
 		}
 
 		$errors          = array();
+		$warnings        = array();
 		$pluginsActiveds = apply_filters(
 			'network_admin_active_plugins',
 			get_option( 'active_plugins' )
@@ -65,18 +66,26 @@ class CheckHealthService {
 		}
 
 		if ( ! in_array( 'woo-better-shipping-calculator-for-brazil/wc-better-shipping-calculator-for-brazil.php', $pluginsActiveds ) && ! is_multisite() ) {
-			$errors[] = 'Você precisa do plugin <a target="_blank" href="https://br.wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/">Calculadora de Frete e Campos Checkout para o Brasil</a> ativado no wordpress para utilizar o plugin do Melhor Envio';
+			$warnings[] = 'Recomendamos a instalação do plugin <a target="_blank" href="https://br.wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/">Calculadora de Frete e Campos Checkout para o Brasil</a> ativado no wordpress para perfeito funcionamento do plugin do Melhor Envio.';
 		}
 
 		$sessionNoticeService = new SessionNoticeService();
+
 		if ( ! empty( $errors ) ) {
 			foreach ( $errors as $err ) {
 				$sessionNoticeService->add( $err, SessionNoticeService::NOTICE_INFO );
 			}
 		}
 
+		if ( ! empty( $warnings ) ) {
+			foreach ( $warnings as $warning ) {
+				$sessionNoticeService->add( $warning, SessionNoticeService::NOTICE_WARNING );
+			}
+		}
+
 		return array(
 			'errors'     => $errors,
+			'warnings'   => $warnings,
 			'errorsPath' => $errorsPath,
 		);
 	}

--- a/Services/CheckHealthService.php
+++ b/Services/CheckHealthService.php
@@ -60,7 +60,6 @@ class CheckHealthService {
 		}
 
 		$errors          = array();
-		$warnings        = array();
 		$pluginsActiveds = apply_filters(
 			'network_admin_active_plugins',
 			get_option( 'active_plugins' )
@@ -83,15 +82,8 @@ class CheckHealthService {
 			}
 		}
 
-		if ( ! empty( $warnings ) ) {
-			foreach ( $warnings as $warning ) {
-				$sessionNoticeService->add( $warning, SessionNoticeService::NOTICE_WARNING );
-			}
-		}
-
 		return array(
 			'errors'     => $errors,
-			'warnings'   => $warnings,
 			'errorsPath' => $errorsPath,
 		);
 	}

--- a/Services/CheckHealthService.php
+++ b/Services/CheckHealthService.php
@@ -50,6 +50,11 @@ class CheckHealthService {
 	 */
 	public function checkPathPlugin( $pathPlugins ) {
 		$errorsPath = array();
+
+        $sessionNoticeService = new SessionNoticeService();
+        $sessionNoticeService->removeNoticesContaning( 'woocommerce-extra-checkout-fields-for-brazil' );
+        $sessionNoticeService->removeNoticesContaning( 'woo-better-shipping-calculator-for-brazil' );
+
 		if ( ! is_dir( $pathPlugins . '/woocommerce' ) ) {
 			$errorsPath[] = 'Defina o path do diretório de plugins nas configurações do plugin do Melhor Envio';
 		}
@@ -65,11 +70,12 @@ class CheckHealthService {
 			$errors[] = 'Você precisa do plugin WooCommerce ativado no WordPress para utilizar o plugin do Melhor Envio';
 		}
 
-		if ( ! in_array( 'woo-better-shipping-calculator-for-brazil/wc-better-shipping-calculator-for-brazil.php', $pluginsActiveds ) && ! is_multisite() ) {
-			$warnings[] = 'Recomendamos a instalação do plugin <a target="_blank" href="https://br.wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/">Calculadora de Frete e Campos Checkout para o Brasil</a> ativado no wordpress para perfeito funcionamento do plugin do Melhor Envio.';
-		}
+		$hasBetterShipping = in_array( 'woo-better-shipping-calculator-for-brazil/wc-better-shipping-calculator-for-brazil.php', $pluginsActiveds );
+		$hasExtraCheckout  = in_array( 'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php', $pluginsActiveds );
 
-		$sessionNoticeService = new SessionNoticeService();
+		if ( ! $hasBetterShipping && ! $hasExtraCheckout && ! is_multisite() ) {
+			$errors[] = 'O plugin do Melhor Envio <strong>necessita obrigatoriamente</strong> de um dos seguintes plugins instalado e ativado para funcionar corretamente: <a target="_blank" href="https://br.wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/">Calculadora de Frete e Campos Checkout para o Brasil</a> ou <a target="_blank" href="https://br.wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/">Brazilian Market on WooCommerce</a>.';
+		}
 
 		if ( ! empty( $errors ) ) {
 			foreach ( $errors as $err ) {

--- a/Services/SessionNoticeService.php
+++ b/Services/SessionNoticeService.php
@@ -118,6 +118,36 @@ class SessionNoticeService {
 		return update_option( self::ID_NOTICES_OPTIONS, $notices );
 	}
 
+    /**
+     * Remove notices by partial text match in stored HTML.
+     *
+     * @param string $needle
+     * @return bool
+     */
+    public function removeNoticesContaning($needle)
+    {
+        if (empty($needle)) {
+            return false;
+        }
+
+        $notices = $this->get();
+        $updated = false;
+
+        foreach ($notices as $hash => $notice) {
+            if (false !== stripos($notice, $needle)) {
+                unset($notices[ $hash ]);
+
+                $updated = true;
+            }
+        }
+
+        if (! $updated) {
+            return false;
+        }
+
+        return update_option(self::ID_NOTICES_OPTIONS, $notices);
+    }
+
 	/**
 	 * function to list all notices
 	 *

--- a/Services/SessionNoticeService.php
+++ b/Services/SessionNoticeService.php
@@ -19,6 +19,8 @@ class SessionNoticeService {
 
 	const NOTICE_INFO = 'notice-info';
 
+	const NOTICE_WARNING = 'notice-warning';
+
 	const TYPES_NOTICE = array(
 		'notice-error',
 		'notice-warning',

--- a/Services/SessionNoticeService.php
+++ b/Services/SessionNoticeService.php
@@ -19,8 +19,6 @@ class SessionNoticeService {
 
 	const NOTICE_INFO = 'notice-info';
 
-	const NOTICE_WARNING = 'notice-warning';
-
 	const TYPES_NOTICE = array(
 		'notice-error',
 		'notice-warning',

--- a/docker/scripts/setup.sh
+++ b/docker/scripts/setup.sh
@@ -25,13 +25,13 @@ $WORDPRESS plugin delete --all --exclude=melhor-envio-cotacao
 
 # Install plugins
 $WORDPRESS plugin install woocommerce
-$WORDPRESS plugin install woocommerce-extra-checkout-fields-for-brazil
+$WORDPRESS plugin install woo-better-shipping-calculator-for-brazil
 $WORDPRESS plugin install wpc-composite-products
 $WORDPRESS plugin install woo-product-bundle
 $WORDPRESS plugin install query-monitor
 
 # Activate plugins
 $WORDPRESS plugin activate woocommerce
-$WORDPRESS plugin activate woocommerce-extra-checkout-fields-for-brazil
+$WORDPRESS plugin activate woo-better-shipping-calculator-for-brazil
 $WORDPRESS plugin activate melhor-envio-cotacao
 $WORDPRESS plugin activate query-monitor

--- a/melhor-envio-beta.php
+++ b/melhor-envio-beta.php
@@ -3,13 +3,13 @@
 Plugin Name: Melhor Envio
 Plugin URI: https://melhorenvio.com.br
 Description: Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
-Version: 2.16.1
+Version: 2.16.2
 Author: Melhor Envio
 Author URI: https://melhorenvio.com.br
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Text Domain: melhor-envio-cotacao
-Requires Plugins: woocommerce, woo-better-shipping-calculator-for-brazil
+Requires Plugins: woocommerce
 Tested up to: 6.9
 Requires PHP: 7.2
 WC requires at least: 4.0

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 === Melhor Envio ===
-Version: 2.16.1
+Version: 2.16.2
 Tags: frete, cotação, logística, envio, melhor envio
 Requires at least: 4.7
 Tested up to: 6.9
-Stable tag: 2.16.1
+Stable tag: 2.16.2
 Requires PHP: 7.2+
 Requires Wordpress 4.0+
 Requires WooCommerce 4.0+
@@ -54,7 +54,7 @@ A instalação do plugin é simples, basta acessar a aba "Plugins > Instalar nov
 
 Ou se preferir basta fazer o download do plugin na página oficial do plugin no portal do Wordpress e mover o arquivo .Zip para o diretório wp-content/plugins. O próximo passo, é acessar todos os plugins pelo menu Plugins -> Plugins instalados, encontrar o plugin "Melhor Envio" e clicar em "Ativar".
 
-Você também vai precisar do plugin <a href"https://wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/" target="_blank">Calculadora de Frete e Campos Checkout para o Brasil</a> para o perfeito funcionamento do plugin do Melhor Envio.
+Recomendamos a instalação do plugin <a href="https://wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/" target="_blank">Calculadora de Frete e Campos Checkout para o Brasil</a> para o perfeito funcionamento do plugin do Melhor Envio.
 
 O próximo passo para utilizar o plugin é gerar um token na plataforma da Melhor Envio. Para isso, você precisa acessar o <a target="_blank" href="https://melhorenvio.com.br/painel/gerenciar/tokens">link</a> e clicar em "Novo token", inserir um nome para o token, selecionar as permissões e clicar em "Salvar". Você deve copiar o token gerado, e colar o mesmo no painel do Wordpress, acessando o menu Melhor Envio -> Token.
 painel administrativo do wordpress e buscar pelo plugin "Melhor Envio" na barra de busca.
@@ -68,6 +68,9 @@ Observação: Atenção com as medidas de unidades utilizadas, cuidado se você 
 Pronto! o plugin do Melhor Envio está funcionando.
 
 == Changelog ==
+
+= 2.16.2 =
+* Altera plugin de campos de checkout para recomendado ao invés de obrigatório
 
 = 2.16.1 =
 * Adiciona envio de NF para JeT e Loggi


### PR DESCRIPTION
## Ações realizadas
- Altera o plugin "Calculadora de Frete e Campos Checkout para o Brasil" (`woo-better-shipping-calculator-for-brazil`) de dependência obrigatória para opcional, permitindo que o Melhor Envio ative e funcione sem ele
- Quando o plugin não está ativo, exibe um aviso amarelo (warning) no admin ao invés de um erro que bloqueava a inicialização
- Bump de versão para 2.16.2