### PR TITLE
fix: corrige erro de sintaxe SQL na consulta de frete Update Method.php

### DIFF
--- a/Models/Method.php
+++ b/Models/Method.php
@@ -12,11 +12,11 @@ class Method {
 		$result = $wpdb->get_results(
             $wpdb->prepare(
                 'select meta_value as method 
-                 from %swoocommerce_order_itemmeta 
+                 from {$wpdb->prefix}woocommerce_order_itemmeta 
                  where meta_key = "method_id" 
                  and order_item_id IN (
                   select order_item_id 
-                  from %swoocommerce_order_items 
+                  from {$wpdb->prefix}woocommerce_order_items 
                   where order_id = %d 
                   and order_item_type = "shipping"
                  )',
@@ -56,7 +56,7 @@ class Method {
 		$enableds = array();
 		$results  = $wpdb->get_results(
             $wpdb->prepare(
-                'select * from %swoocommerce_shipping_zone_methods where is_enabled = 1',
+                'select * from {$wpdb->prefix}woocommerce_shipping_zone_methods where is_enabled = 1',
                 $wpdb->prefix
             )
         );


### PR DESCRIPTION
Substitui o uso incorreto de '%s' no '$wpdb->prepare()' pela interpolação direta '{$wpdb->prefix}' nos nomes das tabelas. Isso resolve o 'WordPress database error' onde o prefixo recebia aspas simples indevidas (ex: 'wp_'tabela), normalizando a consulta de acordo com as diretrizes do WordPress.