### PR TITLE
ci: workflow manual para gerar zip de dev do plugin

### DIFF
--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -53,10 +53,6 @@ jobs:
             --exclude=a.out
 
       - name: Upload plugin artifact
-        # Não zipamos aqui de propósito: o upload-artifact já compacta o que recebe, então
-        # zipar antes geraria um zip dentro do zip baixado (double zip problem). Apontando
-        # pro pai da pasta montada, o download já sai como um único zip com a pasta
-        # 'melhor-envio-cotacao/' na raiz - pronta pra ir em wp-content/plugins/.
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: melhor-envio-cotacao-dev

--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: composer
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -55,7 +55,7 @@ jobs:
           zip -r ../melhor-envio-cotacao-dev.zip melhor-envio-cotacao
 
       - name: Upload zip artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: melhor-envio-cotacao-dev
           path: melhor-envio-cotacao-dev.zip

--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -1,0 +1,62 @@
+name: Build dev zip
+on:
+  workflow_dispatch: {}
+jobs:
+  build:
+    name: Build plugin zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install PHP dependencies
+        run: composer install --optimize-autoloader --no-dev --no-interaction
+
+      - name: Install JS dependencies and build assets
+        run: |
+          npm install
+          npm run build
+
+      - name: Assemble plugin folder
+        run: |
+          mkdir -p dist/melhor-envio-cotacao
+          rsync -a ./ dist/melhor-envio-cotacao/ \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=.idea \
+            --exclude=node_modules \
+            --exclude=dist \
+            --exclude=caddy \
+            --exclude=compose.yml \
+            --exclude=Dockerfile \
+            --exclude=custom-php-settings.ini \
+            --exclude=.env \
+            --exclude=.env.example \
+            --exclude=Makefile \
+            --exclude=.gitignore \
+            --exclude=.gitattributes \
+            --exclude=.distignore \
+            --exclude=a.out
+
+      - name: Zip plugin folder
+        run: |
+          cd dist
+          zip -r ../melhor-envio-cotacao-dev.zip melhor-envio-cotacao
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: melhor-envio-cotacao-dev
+          path: melhor-envio-cotacao-dev.zip
+          retention-days: 14

--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -1,10 +1,13 @@
 name: Build dev zip
 on:
   workflow_dispatch: {}
+permissions: {}
 jobs:
   build:
     name: Build plugin zip
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -49,14 +52,13 @@ jobs:
             --exclude=.distignore \
             --exclude=a.out
 
-      - name: Zip plugin folder
-        run: |
-          cd dist
-          zip -r ../melhor-envio-cotacao-dev.zip melhor-envio-cotacao
-
-      - name: Upload zip artifact
+      - name: Upload plugin artifact
+        # Não zipamos aqui de propósito: o upload-artifact já compacta o que recebe, então
+        # zipar antes geraria um zip dentro do zip baixado (double zip problem). Apontando
+        # pro pai da pasta montada, o download já sai como um único zip com a pasta
+        # 'melhor-envio-cotacao/' na raiz - pronta pra ir em wp-content/plugins/.
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: melhor-envio-cotacao-dev
-          path: melhor-envio-cotacao-dev.zip
+          path: dist
           retention-days: 14

--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           name: melhor-envio-cotacao-dev
           path: dist
-          retention-days: 14
+          retention-days: 7


### PR DESCRIPTION
## O que é

Novo workflow (`workflow_dispatch`, só manual) que gera um zip do plugin pra
testar em ambiente de dev, sem publicar no SVN do wordpress.org.

- `composer install --optimize-autoloader --no-dev`
- `npm install && npm run build`
- empacota tudo exceto git/docker/dev-env/`.env`
- anexa como artifact baixável na run (retenção 14 dias)

Precisa estar mergeado na `main` pra aparecer na aba Actions - depois disso
dá pra rodar escolhendo qualquer branch em "Use workflow from".

## Test plan
- [ ] Merge na main
- [ ] Rodar o workflow manualmente escolhendo uma branch de feature
- [ ] Baixar o artifact e conferir que o zip instala/ativa num WP limpo