### PR TITLE
ci: escolher dev/prod ao gerar o zip do plugin

### DIFF
--- a/.github/workflows/build-dev-zip.yml
+++ b/.github/workflows/build-dev-zip.yml
@@ -1,6 +1,14 @@
-name: Build dev zip
+name: Build plugin zip
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'URL do Melhor Integrador a usar no build'
+        type: choice
+        options:
+          - dev
+          - prod
+        default: dev
 permissions: {}
 jobs:
   build:
@@ -22,6 +30,13 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
+
+      - name: Point Melhor Integrador to staging URL
+        if: ${{ inputs.environment == 'dev' }}
+        run: |
+          for f in melhor-envio-beta.php src/Infrastructure/WordPress/Admin/AdminPage.php; do
+            [ -f "$f" ] && sed -i "s#https://wordpress-envios.melhorenvio.com/#https://wordpress-envios.melhorenvio.work#g" "$f"
+          done
 
       - name: Install PHP dependencies
         run: composer install --optimize-autoloader --no-dev --no-interaction
@@ -55,6 +70,6 @@ jobs:
       - name: Upload plugin artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: melhor-envio-cotacao-dev
+          name: melhor-envio-cotacao-${{ inputs.environment }}
           path: dist
           retention-days: 7


### PR DESCRIPTION
## O que é

Adiciona um input `environment` (dev/prod, default dev) no `workflow_dispatch`
do build de zip, além da branch já escolhível.

- **dev**: troca a URL de produção do Melhor Integrador
  (`wordpress-envios.melhorenvio.com`) pela de staging
  (`wordpress-envios.melhorenvio.work`) só no zip gerado, via `sed` nos
  arquivos já checados fora - não mexe no git/fonte.
- **prod**: builda direto, sem troca (usa a URL de produção que já está no
  código).

## Test plan
- [ ] Merge na main
- [ ] Rodar o workflow escolhendo branch `feat/melhor-integrador-iframe` + `environment: dev`, baixar o zip e conferir que a URL trocada é a de staging
- [ ] Rodar de novo com `environment: prod` e conferir que fica a URL de produção