### PR TITLE
fix(cotacao): corrige crash no fallback de produtos quando CartWooCommerceService retorna vazio

### DIFF
--- a/Helpers/ProductVirtualHelper.php
+++ b/Helpers/ProductVirtualHelper.php
@@ -10,7 +10,7 @@ class ProductVirtualHelper {
 	 */
 	public static function removeVirtuals( $products ) {
 		foreach ( $products as $key => $product ) {
-			if ( $product->is_virtual ) {
+			if ( ! is_object( $product ) || $product->is_virtual ) {
 				unset( $products[ $key ] );
 			}
 		}

--- a/Services/CalculateShippingMethodService.php
+++ b/Services/CalculateShippingMethodService.php
@@ -55,8 +55,12 @@ class CalculateShippingMethodService {
 		}
 
 		if ( empty( $products ) ) {
-			foreach($package['contents'] as $content){
-				$products[] = $content['formatted_data'];
+			if ( $this->isProductPageCalculation( $package ) ) {
+				foreach ( $package['contents'] as $content ) {
+					$products[] = $content['formatted_data'];
+				}
+			} else {
+				$products = ( new \MelhorEnvio\Services\Products\ProductsService() )->filter( $package['contents'] );
 			}
 		}
 

--- a/Services/Products/ProductsService.php
+++ b/Services/Products/ProductsService.php
@@ -121,7 +121,10 @@ class ProductsService {
 				continue;
 			}
 
-			$product    = $item['data'];
+			$product = $item['data'];
+			if ( is_null( $product ) ) {
+				continue;
+			}
 			$products[$key] = $this->normalize(
 				$product,
 				$product->get_price(),


### PR DESCRIPTION
## Problema

Quando `CartWooCommerceService::getProducts()` retorna vazio no checkout, o código entrava no fallback e tentava ler `$content['formatted_data']` dos items de `$package['contents']`.

Essa key **só existe** em packages montados por `QuotationProductPageService` (cálculo na página do produto). No checkout normal, os items são arrays WooCommerce padrão (`data`, `quantity`, `product_id`, ...) — sem `formatted_data`.

**Cascata de erros:**
1. `$content['formatted_data']` → `null` (key inexistente)
2. `ProductVirtualHelper::removeVirtuals()` → `Attempt to read property "is_virtual" on null`
3. `ProductsService::filter()` → `Call to a member function get_price() on null`

## Correções

- **`CalculateShippingMethodService`**: fallback para cart normal usa `ProductsService::filter($package['contents'])` em vez de `formatted_data`; product page continua usando `formatted_data` (correto)
- **`ProductsService::filter()`**: guarda contra `$item['data']` null (produto deletado/indisponível)
- **`ProductVirtualHelper::removeVirtuals()`**: guarda contra não-objetos no array de produtos

## Teste

Reproduzir: checkout com produto válido em ambiente onde `WC()->cart` não está populado no momento do hook de cálculo de frete → warnings e fatal error desaparecem.