### PR TITLE
fix(models): corrige prefixo de tabela SQL no wpdb->prepare

### DIFF
--- a/Models/Method.php
+++ b/Models/Method.php
@@ -11,17 +11,15 @@ class Method {
 
 		$result = $wpdb->get_results(
             $wpdb->prepare(
-                'select meta_value as method 
-                 from %swoocommerce_order_itemmeta 
-                 where meta_key = "method_id" 
+                "select meta_value as method
+                 from {$wpdb->prefix}woocommerce_order_itemmeta
+                 where meta_key = 'method_id'
                  and order_item_id IN (
-                  select order_item_id 
-                  from %swoocommerce_order_items 
-                  where order_id = %d 
-                  and order_item_type = "shipping"
-                 )',
-                $wpdb->prefix,
-                $wpdb->prefix,
+                  select order_item_id
+                  from {$wpdb->prefix}woocommerce_order_items
+                  where order_id = %d
+                  and order_item_type = 'shipping'
+                 )",
                 $order_id
             )
         );
@@ -56,8 +54,7 @@ class Method {
 		$enableds = array();
 		$results  = $wpdb->get_results(
             $wpdb->prepare(
-                'select * from %swoocommerce_shipping_zone_methods where is_enabled = 1',
-                $wpdb->prefix
+                "select * from {$wpdb->prefix}woocommerce_shipping_zone_methods where is_enabled = 1"
             )
         );
 


### PR DESCRIPTION
## Summary

- Substitui `%s` por `{$wpdb->prefix}` na interpolação direta do nome das tabelas
- `wpdb->prepare()` envolve args `%s` em aspas simples (WP 6.1+), gerando `'wp_'tabela` — sintaxe SQL inválida
- Afeta `getMethodShipmentSelected` e `getArrayShippingMethodsEnabledByZoneMelhorEnvio`

Fecha o mesmo problema reportado em #233, com fix completo (a PR #233 ainda deixava `$wpdb->prefix` como argumento na query de single-quote string, que não interpola variável).

## Test plan

- [ ] Realizar checkout com método de envio Melhor Envio — sem erro de SQL no log
- [ ] Verificar que métodos de envio por zona carregam corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)