### PR TITLE
feat(settings): adiciona endpoints REST de settings e IntegradorSettingsService

### DIFF
--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -17,6 +17,8 @@ use MelhorEnvio\Http\Controllers\Auth\DisconnectController;
 use MelhorEnvio\Http\Controllers\Order\OrderMetaBackfillController;
 use MelhorEnvio\Http\Controllers\Auth\QuotationTokenController;
 use MelhorEnvio\Http\Controllers\Auth\SaveSecretController;
+use MelhorEnvio\Http\Controllers\Settings\GetSettingsController;
+use MelhorEnvio\Http\Controllers\Settings\SaveSettingsController;
 use MelhorEnvio\Services\Shipping\MelhorEnvioShippingService;
 
 final class HookManager {
@@ -42,6 +44,12 @@ final class HookManager {
 
 		$disconnectEndpoint = $this->container->get( DisconnectController::class );
 		$disconnectEndpoint->register();
+
+		$getSettingsEndpoint = $this->container->get( GetSettingsController::class );
+		$getSettingsEndpoint->register();
+
+		$saveSettingsEndpoint = $this->container->get( SaveSettingsController::class );
+		$saveSettingsEndpoint->register();
 
 		$quotationAjaxHandler = $this->container->get( QuotationController::class );
 		$quotationAjaxHandler->register();

--- a/src/Http/Controllers/Concerns/ValidatesAuthentication.php
+++ b/src/Http/Controllers/Concerns/ValidatesAuthentication.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelhorEnvio\Http\Controllers\Concerns;
+
+use MelhorEnvio\Services\Auth\SecretService;
+use MelhorEnvio\Services\Auth\SignatureService;
+use WP_REST_Request;
+
+trait ValidatesAuthentication {
+
+	private ?SignatureService $signatureManager = null;
+
+	private ?SecretService $secretManager = null;
+
+	public function checkSignaturePermission( WP_REST_Request $request ): bool {
+		$signature = $request->get_header( 'X-ME-Signature' );
+
+		if ( empty( $signature ) || $this->signatureManager === null ) {
+			return false;
+		}
+
+		return $this->signatureManager->validateSignature( $signature );
+	}
+
+	public function checkSecretPermission( WP_REST_Request $request ): bool {
+		$secret = $request->get_header( 'X-ME-Secret' );
+
+		if ( empty( $secret ) || $this->secretManager === null ) {
+			return false;
+		}
+
+		$storedSecret = $this->secretManager->getSecret();
+
+		return $storedSecret !== null && hash_equals( $storedSecret, $secret );
+	}
+}

--- a/src/Http/Controllers/Settings/GetSettingsController.php
+++ b/src/Http/Controllers/Settings/GetSettingsController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelhorEnvio\Http\Controllers\Settings;
+
+use MelhorEnvio\Http\Controllers\Concerns\ValidatesAuthentication;
+use MelhorEnvio\Http\Controllers\RestEndpointContract;
+use MelhorEnvio\Services\Auth\SecretService;
+use MelhorEnvio\Services\Settings\IntegradorSettingsService;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class GetSettingsController extends RestEndpointContract {
+
+	use ValidatesAuthentication;
+
+	private IntegradorSettingsService $settingsService;
+	private const ROUTE = '/settings';
+
+	public function __construct(
+		SecretService $secretManager,
+		IntegradorSettingsService $settingsService
+	) {
+		$this->secretManager  = $secretManager;
+		$this->settingsService = $settingsService;
+	}
+
+	public function registerRoute(): void {
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::ROUTE,
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'handleRequest' ),
+				'permission_callback' => array( $this, 'checkSecretPermission' ),
+			)
+		);
+	}
+
+	public function handleRequest( WP_REST_Request $request ): WP_REST_Response {
+		return new WP_REST_Response( $this->settingsService->getSettings(), 200 );
+	}
+}

--- a/src/Http/Controllers/Settings/SaveSettingsController.php
+++ b/src/Http/Controllers/Settings/SaveSettingsController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelhorEnvio\Http\Controllers\Settings;
+
+use MelhorEnvio\Http\Controllers\Concerns\ValidatesAuthentication;
+use MelhorEnvio\Http\Controllers\RestEndpointContract;
+use MelhorEnvio\Services\Auth\SecretService;
+use MelhorEnvio\Services\Settings\IntegradorSettingsService;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class SaveSettingsController extends RestEndpointContract {
+
+	use ValidatesAuthentication;
+
+	private IntegradorSettingsService $settingsService;
+	private const ROUTE = '/settings';
+
+	public function __construct(
+		SecretService $secretManager,
+		IntegradorSettingsService $settingsService
+	) {
+		$this->secretManager  = $secretManager;
+		$this->settingsService = $settingsService;
+	}
+
+	public function registerRoute(): void {
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::ROUTE,
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'handleRequest' ),
+				'permission_callback' => array( $this, 'checkSecretPermission' ),
+			)
+		);
+	}
+
+	public function handleRequest( WP_REST_Request $request ): WP_REST_Response {
+		$body = $request->get_json_params();
+
+		if ( ! $this->isValidPayload( $body ) ) {
+			return new WP_REST_Response( array( 'message' => 'Invalid payload.' ), 400 );
+		}
+
+		$settings = $this->sanitizeSettings( $body );
+		$saved    = $this->settingsService->saveSettings( $settings );
+
+		if ( ! $saved ) {
+			return new WP_REST_Response( array( 'message' => 'Failed to save settings.' ), 500 );
+		}
+
+		return new WP_REST_Response( $settings, 200 );
+	}
+
+	private function isValidPayload( mixed $body ): bool {
+		if ( ! is_array( $body ) ) {
+			return false;
+		}
+
+		if ( isset( $body['calculator'] ) && ! is_array( $body['calculator'] ) ) {
+			return false;
+		}
+
+		if ( isset( $body['dimensions_default'] ) && ! is_array( $body['dimensions_default'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function sanitizeSettings( array $body ): array {
+		$settings = array();
+
+		if ( isset( $body['calculator'] ) ) {
+			$calc = $body['calculator'];
+			$settings['calculator'] = array(
+				'enabled'  => isset( $calc['enabled'] ) ? (bool) $calc['enabled'] : true,
+				'position' => isset( $calc['position'] ) ? sanitize_text_field( $calc['position'] ) : 'woocommerce_before_add_to_cart_button',
+			);
+		}
+
+		if ( isset( $body['dimensions_default'] ) ) {
+			$dim = $body['dimensions_default'];
+			$settings['dimensions_default'] = array(
+				'height' => isset( $dim['height'] ) ? (float) $dim['height'] : 10,
+				'width'  => isset( $dim['width'] ) ? (float) $dim['width'] : 10,
+				'length' => isset( $dim['length'] ) ? (float) $dim['length'] : 10,
+				'weight' => isset( $dim['weight'] ) ? (float) $dim['weight'] : 11,
+			);
+		}
+
+		if ( isset( $body['checkout'] ) && is_array( $body['checkout'] ) ) {
+			$checkout = $body['checkout'];
+			$allowed_document_types = [ 'both', 'cpf_only', 'cnpj_only' ];
+			$document_type = sanitize_text_field( $checkout['document_type'] ?? 'both' );
+
+			$settings['checkout'] = array(
+				'document_type'        => in_array( $document_type, $allowed_document_types, true ) ? $document_type : 'both',
+				'require_number'       => isset( $checkout['require_number'] ) ? (bool) $checkout['require_number'] : true,
+				'require_neighborhood' => isset( $checkout['require_neighborhood'] ) ? (bool) $checkout['require_neighborhood'] : true,
+			);
+		}
+
+		return $settings;
+	}
+}

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -20,6 +20,7 @@ use MelhorEnvio\Services\Quotation\PostalCodeLocationClientService;
 use MelhorEnvio\Http\Controllers\Auth\DisconnectController;
 use MelhorEnvio\Http\Controllers\Auth\QuotationTokenController;
 use MelhorEnvio\Http\Controllers\Auth\SaveSecretController;
+use MelhorEnvio\Services\Settings\IntegradorSettingsService;
 use MelhorEnvio\Services\Shipping\CartItemsBuilderService;
 use MelhorEnvio\Services\Shipping\ShippingZoneService;
 use wpdb;
@@ -34,6 +35,7 @@ final class CoreServiceProvider extends AbstractServiceProvider {
 			AdminMenuController::class,
 			static fn( Container $container ) => new AdminMenuController( $container )
 		);
+		$this->container->singleton( IntegradorSettingsService::class, IntegradorSettingsService::class );
 		$this->container->singleton( SecretService::class, SecretService::class );
 		$this->container->singleton( SignatureService::class, SignatureService::class );
 		$this->container->singleton(
@@ -49,10 +51,16 @@ final class CoreServiceProvider extends AbstractServiceProvider {
 			static fn( Container $container ) => new QuotationController(
 				$container->get( MelhorEnvioApiClientService::class ),
 				$container->get( CartItemsBuilderService::class ),
-				$container->get( PostalCodeLocationClientService::class )
+				$container->get( PostalCodeLocationClientService::class ),
+				$container->get( IntegradorSettingsService::class )
 			)
 		);
-		$this->container->singleton( CartItemsBuilderService::class, CartItemsBuilderService::class );
+		$this->container->singleton(
+			CartItemsBuilderService::class,
+			static fn( Container $container ) => new CartItemsBuilderService(
+				$container->get( IntegradorSettingsService::class )
+			)
+		);
 		$this->container->singleton( ProductShippingCalculatorController::class, ProductShippingCalculatorController::class );
 		$this->container->singleton( MelhorEnvioApiClientService::class, MelhorEnvioApiClientService::class );
 		$this->container->singleton( PostalCodeLocationClientService::class, PostalCodeLocationClientService::class );

--- a/src/Services/Settings/IntegradorSettingsService.php
+++ b/src/Services/Settings/IntegradorSettingsService.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MelhorEnvio\Services\Settings;
+
+final class IntegradorSettingsService {
+
+	private const OPTION_KEY                    = 'melhor_envio_integrador_settings';
+	private const LEGACY_HIDE_CALCULATOR        = 'melhorenvio_hide_calculator_product';
+	private const LEGACY_CALCULATOR_POSITION    = 'melhor_envio_option_where_show_calculator';
+	private const LEGACY_DIMENSION_DEFAULT      = 'melhor_envio_option_dimension_default';
+	private const DEFAULT_CALCULATOR_POSITION   = 'woocommerce_before_add_to_cart_button';
+	private const DEFAULT_DIMENSION_HEIGHT      = 10;
+	private const DEFAULT_DIMENSION_WIDTH       = 10;
+	private const DEFAULT_DIMENSION_LENGTH      = 10;
+	private const DEFAULT_DIMENSION_WEIGHT      = 11;
+	private const DEFAULT_DOCUMENT_TYPE         = 'both';
+	private const DEFAULT_REQUIRE_NUMBER        = true;
+	private const DEFAULT_REQUIRE_NEIGHBORHOOD  = true;
+
+	public function getSettings(): array {
+		$stored = get_option( self::OPTION_KEY );
+
+		if ( is_array( $stored ) && ! empty( $stored ) ) {
+			return $stored;
+		}
+
+		$legacy = $this->getLegacySettings();
+
+		if ( ! empty( $legacy ) ) {
+			return $legacy;
+		}
+
+		return $this->getDefaults();
+	}
+
+	public function saveSettings( array $settings ): bool {
+		$updated = update_option( self::OPTION_KEY, $settings );
+
+		// update_option returns false both on failure and when value is unchanged.
+		// If unchanged, consider it a success.
+		if ( ! $updated && get_option( self::OPTION_KEY ) === $settings ) {
+			return true;
+		}
+
+		return (bool) $updated;
+	}
+
+	private function getLegacySettings(): array {
+		$hideCalculator = get_option( self::LEGACY_HIDE_CALCULATOR );
+		$position       = get_option( self::LEGACY_CALCULATOR_POSITION );
+		$dimensions     = get_option( self::LEGACY_DIMENSION_DEFAULT );
+
+		if ( $hideCalculator === false && $position === false && $dimensions === false ) {
+			return array();
+		}
+
+		$defaults = $this->getDefaults();
+
+		$calculatorEnabled = ! ( $hideCalculator === '1' || $hideCalculator === 1 || $hideCalculator === true );
+
+		$calculatorPosition = ( is_string( $position ) && ! empty( $position ) )
+			? $position
+			: self::DEFAULT_CALCULATOR_POSITION;
+
+		$dimensionsDefault = $defaults['dimensions_default'];
+		if ( is_array( $dimensions ) && ! empty( $dimensions ) ) {
+			$dimensionsDefault = array(
+				'height' => isset( $dimensions['height'] ) ? (float) $dimensions['height'] : self::DEFAULT_DIMENSION_HEIGHT,
+				'width'  => isset( $dimensions['width'] ) ? (float) $dimensions['width'] : self::DEFAULT_DIMENSION_WIDTH,
+				'length' => isset( $dimensions['length'] ) ? (float) $dimensions['length'] : self::DEFAULT_DIMENSION_LENGTH,
+				'weight' => isset( $dimensions['weight'] ) ? (float) $dimensions['weight'] : self::DEFAULT_DIMENSION_WEIGHT,
+			);
+		}
+
+		return array(
+			'calculator'        => array(
+				'enabled'  => $calculatorEnabled,
+				'position' => $calculatorPosition,
+			),
+			'dimensions_default' => $dimensionsDefault,
+		);
+	}
+
+	private function getDefaults(): array {
+		return array(
+			'calculator'        => array(
+				'enabled'  => true,
+				'position' => self::DEFAULT_CALCULATOR_POSITION,
+			),
+			'dimensions_default' => array(
+				'height' => self::DEFAULT_DIMENSION_HEIGHT,
+				'width'  => self::DEFAULT_DIMENSION_WIDTH,
+				'length' => self::DEFAULT_DIMENSION_LENGTH,
+				'weight' => self::DEFAULT_DIMENSION_WEIGHT,
+			),
+			'checkout' => array(
+				'document_type'       => self::DEFAULT_DOCUMENT_TYPE,
+				'require_number'      => self::DEFAULT_REQUIRE_NUMBER,
+				'require_neighborhood' => self::DEFAULT_REQUIRE_NEIGHBORHOOD,
+			),
+		);
+	}
+
+	public function getCheckoutSettings(): array {
+		$settings = $this->getSettings();
+		$defaults = $this->getDefaults()['checkout'];
+		$checkout = $settings['checkout'] ?? array();
+
+		return array(
+			'document_type'        => $checkout['document_type'] ?? $defaults['document_type'],
+			'require_number'       => $checkout['require_number'] ?? $defaults['require_number'],
+			'require_neighborhood' => $checkout['require_neighborhood'] ?? $defaults['require_neighborhood'],
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adiciona `IntegradorSettingsService` como fonte única de verdade para settings do integrador (calculadora, dimensões padrão, campos de checkout), com fallback transparente para as options legadas do WP
- Expõe `GET /wp-json/melhor-envio/v1/settings` e `POST /wp-json/melhor-envio/v1/settings`, ambos protegidos via `X-ME-Secret`
- Extrai lógica de autenticação reutilizável para o trait `ValidatesAuthentication` (usado pelos dois controllers acima)

## Test plan

- [ ] `GET /settings` sem header `X-ME-Secret` retorna 401
- [ ] `GET /settings` com secret válido retorna settings (fallback legacy se option nova vazia)
- [ ] `POST /settings` com payload inválido retorna 400
- [ ] `POST /settings` com payload válido persiste em `melhor_envio_integrador_settings` e retorna 200
- [ ] Instância sem nenhuma option configurada retorna defaults (`calculator.enabled=true`, dimensões `10/10/10/11g`, `checkout.document_type=both`)

## Contexto

Base para as próximas branches:
- `feat/wp-auth-controllers-refactor` — aplica o trait nos controllers de auth existentes
- `feat/wp-calculator-migration` — migra calculadora para ler do `IntegradorSettingsService`
- `feat/wp-checkout-fields` — migra campos de checkout para ler do `IntegradorSettingsService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)